### PR TITLE
Clean up dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,10 +15,8 @@ tokio-stream = { version = "0.1.10", features = ["sync"] }
 num-traits = "0.2.15"
 num-derive = "0.3.3"
 anyhow = "1.0.66"
-bincode = "1.3.3"
 byteorder = "1.4.3"
 async-trait = "0.1.58"
-winit = "0.27.5"
 
 [dependencies.uuid]
 version = "1.2.1"
@@ -27,3 +25,6 @@ features = [
     "fast-rng",          # Use a faster (but still sufficiently random) RNG
     "macro-diagnostics", # Enable better diagnostics for compile-time UUIDs
 ]
+
+[dev-dependencies]
+winit = "0.27.5"


### PR DESCRIPTION
1) winit is only needed in one of the examples, make it a dev-dependency.
   This avoids the need to build it in downstream packages.

2) bincode seems entirely unused, removed it.